### PR TITLE
Fix qt module not included after options change

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -77,7 +77,15 @@ class QtConan(ConanFile):
                 self.requires("OpenSSL/1.0.2l@conan/stable")
 
     def source(self):
-        submodules = ["qtbase"]
+        self.run("git clone https://code.qt.io/qt/qt5.git")
+        self.run("cd %s && git checkout %s" % (self.source_dir, self.version))
+        self.run("cd %s && git submodule update --init %s" % (self.source_dir, "qtbase"))
+
+        if self.settings.os != "Windows":
+            self.run("chmod +x ./%s/configure" % self.source_dir)
+
+    def build(self):
+        submodules = []
 
         if self.options.activeqt:
             submodules.append("qtactiveqt")
@@ -108,14 +116,9 @@ class QtConan(ConanFile):
         if self.options.xmlpatterns:
             submodules.append("qtxmlpatterns")
 
-        self.run("git clone https://code.qt.io/qt/qt5.git")
-        self.run("cd %s && git checkout %s" % (self.source_dir, self.version))
-        self.run("cd %s && git submodule update --init %s" % (self.source_dir, " ".join(submodules)))
+        if len(submodules) > 0:
+            self.run("cd %s && git submodule update --init %s" % (self.source_dir, " ".join(submodules)))
 
-        if self.settings.os != "Windows":
-            self.run("chmod +x ./%s/configure" % self.source_dir)
-
-    def build(self):
         args = ["-opensource", "-confirm-license", "-nomake examples", "-nomake tests",
                 "-prefix %s" % self.package_folder]
         if not self.options.shared:


### PR DESCRIPTION
Steps to reproduce issue:

1. Add this package into project's conanfile.txt without extra option
2. Run `conan install .`
3. Add option to conanfile.txt for Qt, i.e.: `Qt:tools=True`
4. Run `conan install . --build Qt`
5. After build and install by conan, new package (hash changed) was generated, but you will find that nothing actually change compare to previous package with default option. qttools is still missing.

I'm new to conan, I took hours to read conan document and finally find out the cause. 
If the package is in local cache, after option change, seams conan will skip `source` procedure, went straight `build`, and this recipe checkout qt modules specified by options during `source` procedure. 

That's why the qt modules specified by options did not get included as expected. I solved this by moving repository submodule init into build procedure and keep only qtbase init in source procedure.